### PR TITLE
Update block fork height

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -91,7 +91,7 @@ static const struct {
 } mainnet_hard_forks[] = {
  // version 1 from the start of the blockchain
  { 1, 0, 0, 1581800400 },
- { 15, 5, 0, 1581806100 }
+ { 15, 1, 0, 1581806100 }
 };
 static const uint64_t mainnet_hard_fork_version_1_till = 1;
 
@@ -103,7 +103,7 @@ static const struct {
 } testnet_hard_forks[] = {
  // version 1 from the start of the blockchain
  { 1, 0, 0, 1581800400 },
- { 15, 5, 0, 1581806100 }
+ { 15, 1, 0, 1581806100 }
 };
 static const uint64_t testnet_hard_fork_version_1_till = 1;
 
@@ -115,7 +115,7 @@ static const struct {
 } stagenet_hard_forks[] = {
  // version 1 from the start of the blockchain
  { 1, 0, 0, 1581800400 },
- { 15, 5, 0, 1581806100 }
+ { 15, 1, 0, 1581806100 }
 };
 static const uint64_t stagenet_hard_fork_version_1_till = 1;
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1,3 +1,4 @@
+// Copyright (c) 2020 The Galaxia Project
 // Copyright (c) 2018-2019, The Arqma Network
 // Copyright (c) 2014-2018, The Monero Project
 //
@@ -89,16 +90,8 @@ static const struct {
  time_t time;
 } mainnet_hard_forks[] = {
  // version 1 from the start of the blockchain
- { 1, 0, 0, 1341378000 },
- { 7, 1, 0, 1528750800 },
- { 8, 100, 0, 1528751200 },
- { 9, 7000, 0, 1530320400 },
- { 10, 61250, 0, 1543615200 },
- { 11, 131650, 0, 1552424400 },
- { 12, 183700, 0, 1558656000 },
- { 13, 248200, 0, 1566511680 },
- { 14, 248920, 0, 1566598080 },
- { 15, 303666, 0, 1573257000 }
+ { 1, 0, 0, 1581800400 },
+ { 15, 5, 0, 1581806100 }
 };
 static const uint64_t mainnet_hard_fork_version_1_till = 1;
 
@@ -109,15 +102,8 @@ static const struct {
  time_t time;
 } testnet_hard_forks[] = {
  // version 1 from the start of the blockchain
- { 1, 0, 0, 1341378000 },
- { 7, 1, 0, 1528750800 },
- { 8, 10, 0, 1528751200 },
- { 9, 20, 0, 1530248400 },
- { 10, 100, 0, 1538352000 },
- { 11, 800, 0, 1552424400 },
- { 12, 1000, 0, 1552824400 },
- { 13, 2000, 0, 1566511680 },
- { 14, 3000, 0, 1566598080 }
+ { 1, 0, 0, 1581800400 },
+ { 15, 5, 0, 1581806100 }
 };
 static const uint64_t testnet_hard_fork_version_1_till = 1;
 
@@ -128,16 +114,8 @@ static const struct {
  time_t time;
 } stagenet_hard_forks[] = {
  // version 1 from the start of the blockchain
- { 1, 0, 0, 1341378000 },
- { 7, 1, 0, 1528750800 },
- { 8, 100, 0, 1528751200 },
- { 9, 200, 0, 1530248400 },
- { 10, 500, 0, 1538352000 },
- { 11, 800, 0, 1552424400 },
- { 12, 1500, 0, 1554336000 },
- { 13, 2000, 0, 1560348000 },
- { 14, 2720, 0, 1560351600 },
- { 15, 12100, 0, 1570414500 }
+ { 1, 0, 0, 1581800400 },
+ { 15, 5, 0, 1581806100 }
 };
 static const uint64_t stagenet_hard_fork_version_1_till = 1;
 


### PR DESCRIPTION
At last you can jump in to v15 which is current version, no need to pass other blocks